### PR TITLE
added configuration for uniform registration feature of distributor

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         run: job-executor-service
+        app.kubernetes.io/name: job-executor-service
+        app.kubernetes.io/version: 0.1.1
     spec:
       containers:
         - name: job-executor-service
@@ -30,7 +32,7 @@ spec:
             - name: INIT_CONTAINER_IMAGE
               value: 'keptnsandbox/job-executor-service-initcontainer:0.1.1'
         - name: distributor
-          image: keptn/distributor:0.8.3
+          image: keptn/distributor:0.8.4
           livenessProbe:
             httpGet:
               path: /health
@@ -54,6 +56,31 @@ spec:
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
+            - name: VERSION
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
+            - name: K8S_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
       serviceAccountName: job-executor-service
 ---
 # Expose job-executor-service via Port 8080 within the cluster


### PR DESCRIPTION
In Keptn 0.8.4, the distributor will be extended with the functionality of registering itself as a Keptn uniform integration at the Keptn's Uniform API.

To enable this feature, the following changes need to be made:

First, the image of the `distributor` container of the deployment needs to be set to `keptn/distributor:0.8.4`:

```
        - name: distributor
              image: keptn/distributor:0.8.4
```

Second, the following environment variables have to be added to the `distributor` container:

```
            - name: VERSION
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
            - name: K8S_DEPLOYMENT_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
            - name: K8S_POD_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.name
            - name: K8S_NAMESPACE
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
            - name: K8S_NODE_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
```

Last but not least, ensure that the labels `app.kubernetes.io/version` and `app.kubernetes.name` are available under `spec.template.metadata.labels` in the K8s deployment:

```
        app.kubernetes.io/name: job-executor-service
        app.kubernetes.io/version: 0.1.1
```


❗ Note that this PR should only be merged once Keptn 0.8.4 has been released officially


Once this change has been released and installed in the Kubernetes cluster, the integration/service should be visible in Keptn's Bridge Uniform screen:
![image](https://user-images.githubusercontent.com/56065213/122389276-12e23200-cf71-11eb-955d-a636cb42211b.png)

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>