### PR TITLE
Define initcontainer image values used in configmap in values.yaml

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: job-service-config
 data:
   job_namespace: "{{ .Release.Namespace }}"
-  init_container_image: "keptnsandbox/job-executor-service-initcontainer:0.1.1"
+  init_container_image: "{{ .Values.jobexecutorserviceinitcontainer.image.repository }}:{{ .Values.jobexecutorserviceinitcontainer.image.tag | default .Chart.AppVersion }}"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^[a-z][a-z0-9-./]{2,63}$"
+              "pattern": "^[a-z0-9-./]{2,127}$"
             },
             "pullPolicy": {
               "enum": [
@@ -71,6 +71,21 @@
           "properties": {
             "enabled": {
               "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "jobexecutorserviceinitcontainer": {
+      "type": "object",
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "image": {
+          "properties": {
+            "repository": {
+              "pattern": "^[a-z0-9-./]{2,127}$"
             }
           }
         }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,6 +6,11 @@ jobexecutorservice:
   service:
     enabled: true                            # Creates a Kubernetes Service for the job-executor-service
 
+jobexecutorserviceinitcontainer:
+  image:
+    repository: docker.io/keptnsandbox/job-executor-service-initcontainer # Container Image Name
+    tag: ""                                                               # Container Tag
+
 distributor:
   stageFilter: ""                            # Sets the stage this helm service belongs to
   serviceFilter: ""                          # Sets the service this helm service belongs to


### PR DESCRIPTION
* Define initcontainer values from `configmap` in `values.yaml`
* Extend pattern of image property to allow repositories starting with numbers and longer names (aws ecr)