### PR TITLE
Configurable resource quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ actions:
     silent: true
 ```
 
-### Kubernetes resource quotas
+### Resource quotas for jobs
 
 The `initcontainer` and the `job` container will use the default resource quotas defined as environment variables. They
 can be set in [`deploy/service.yaml`](deploy/service.yaml):

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ actions:
 The tasks of an action are executed if the event name matches. Wildcards can also be used, e.g.
 
 ```yaml
-    - name: "sh.keptn.event.*.triggered"
+- name: "sh.keptn.event.*.triggered"
 ```
 
 Would match events `sh.keptn.event.test.triggered`, `sh.keptn.event.deployment.triggered` and so on.
@@ -66,9 +66,9 @@ Would match events `sh.keptn.event.test.triggered`, `sh.keptn.event.deployment.t
 Optionally the following section can be added to an event:
 
 ```yaml
-      jsonpath:
-        property: "$.data.test.teststrategy"
-        match: "locust"
+jsonpath:
+  property: "$.data.test.teststrategy"
+  match: "locust"
 ```
 
 If the service receives an event which matches the name, and the jsonpath match expression, the specified tasks are
@@ -106,14 +106,14 @@ executed. E.g. the following cloud event would match the jsonpath above:
 The configuration contains the following section:
 
 ```yaml
-    tasks:
-      - name: "Run locust smoke tests"
-        files:
-          - locust/basic.py
-          - locust/import.py
-          - locust/locust.conf
-        image: "locustio/locust"
-        cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
+tasks:
+  - name: "Run locust smoke tests"
+    files:
+      - locust/basic.py
+      - locust/import.py
+      - locust/locust.conf
+    image: "locustio/locust"
+    cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
 ```
 
 It contains the tasks which should be executed as Kubernetes job. The service schedules a different job for each of
@@ -135,11 +135,11 @@ The following environment variable has the name `HOST`, and the value is whateve
 jsonpath `$.data.deployment.deploymentURIsLocal[0]` resolves to.
 
 ```yaml
-        cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
-        env:
-          - name: HOST
-            value: "$.data.deployment.deploymentURIsLocal[0]"
-            valueFrom: event
+cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
+env:
+  - name: HOST
+    value: "$.data.deployment.deploymentURIsLocal[0]"
+    valueFrom: event
 ```
 
 In the above example the json path for `HOST` would resolve into `https://keptn.sh` for the below event
@@ -184,10 +184,10 @@ The following configuration looks up a kubernetes secret with the name `locust-s
 secret will be available as separate environment variables in the job.
 
 ```yaml
-        cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/$(FILE) --host $(HOST)"
-        env:
-          - name: locust-secret
-            valueFrom: secret
+cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/$(FILE) --host $(HOST)"
+env:
+  - name: locust-secret
+    valueFrom: secret
 ```
 
 With the secret below, there will be two environment variables available in the job. `HOST` with the
@@ -214,10 +214,10 @@ metadata:
 Files can be added to your running tasks by specifying them in the `files` section of your tasks:
 
 ```yaml
-        files:
-          - locust/basic.py
-          - locust/import.py
-          - locust/locust.conf
+files:
+  - locust/basic.py
+  - locust/import.py
+  - locust/locust.conf
 ```
 
 This is done by using an `initcontainer` for the scheduled Kubernetes Job which prepares the `èmptyDir` volume mounted
@@ -228,7 +228,7 @@ When using these files in your container command, please make sure to reference 
 E.g.:
 
 ```yaml
-        cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py"
+cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py"
 ```
 
 ### Silent mode
@@ -243,6 +243,64 @@ actions:
   - name: "Run locust"
     silent: true
 ```
+
+### Kubernetes resource quotas
+
+The `initcontainer` and the `job` container will use the default resource quotas defined as environment variables. They
+can be set in [`deploy/service.yaml`](deploy/service.yaml):
+
+```yaml
+- name: DEFAULT_RESOURCE_LIMITS_CPU
+  value: "1"
+- name: DEFAULT_RESOURCE_LIMITS_MEMORY
+  value: "512Mi"
+- name: DEFAULT_RESOURCE_REQUESTS_CPU
+  value: "50m"
+- name: DEFAULT_RESOURCE_REQUESTS_MEMORY
+  value: "128Mi"
+```
+
+or for helm in [`helm/templates/configmap.yaml`](helm/templates/configmap.yaml):
+
+```yaml
+default_resource_limits_cpu: "1"
+default_resource_limits_memory: "512Mi"
+default_resource_requests_cpu: "50m"
+default_resource_requests_memory: "128Mi"
+```
+
+The default resource quotas can be easily overwritten for each task. Add the following block to the configuration on
+task level:
+
+```yaml
+tasks:
+  - name: "Run locust smoke tests"
+    ...
+    resources:
+      limits:
+        cpu: 1
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+```
+
+Now each job that gets spawned for the task will have the configured resource quotas. There is no need to specify all
+values, as long as the configuration makes sense for kubernetes. E.g. the following configuration
+
+```yaml
+tasks:
+  - name: "Run locust smoke tests"
+    ...
+    resources:
+      limits:
+        cpu: 1
+      requests:
+        cpu: 50m
+```
+
+would result in resource quotas for `cpu`, but in none for `memory`. If the `resources` block is present
+(even if empty), all default resource quotas are ignored for this task.
 
 ### Remote Control Plane
 
@@ -384,8 +442,8 @@ To make use of the built-in automation using GH Actions for releasing a new vers
 * check the output of GH Actions builds for the release branch,
 * verify that your image was built and pushed to DockerHub with the right tags,
 * update the image tags for `job-executor-service` and `job-executor-service-initcontainer`
-  in [deploy/service.yaml](deploy/service.yaml), [helm/Chart.yaml](helm/Chart.yaml),
-  [helm/values.yaml](helm/values.yaml) and [helm/templates/configmap.yaml](helm/templates/configmap.yaml),
+  in [`deploy/service.yaml`](deploy/service.yaml), [`helm/Chart.yaml`](helm/Chart.yaml),
+  [`helm/values.yaml`](helm/values.yaml) and [`helm/templates/configmap.yaml`](helm/templates/configmap.yaml),
 * test your service against a working Keptn installation.
 
 If any problems occur, fix them in the release branch and test them again.

--- a/cmd/job-executor-service/main.go
+++ b/cmd/job-executor-service/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	v1 "k8s.io/api/core/v1"
-	"keptn-sandbox/job-executor-service/pkg/config"
 	"keptn-sandbox/job-executor-service/pkg/eventhandler"
 	"keptn-sandbox/job-executor-service/pkg/k8sutils"
 	"log"
@@ -96,7 +95,7 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		Event:       event,
 		EventData:   eventData,
 		ServiceName: ServiceName,
-		JobSettings: config.JobSettings{
+		JobSettings: k8sutils.JobSettings{
 			JobNamespace: env.JobNamespace,
 			InitContainerConfigurationServiceAPIEndpoint: env.InitContainerConfigurationServiceAPIEndpoint,
 			KeptnAPIToken:               env.KeptnAPIToken,

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -35,7 +35,7 @@ spec:
             - name: JOB_NAMESPACE
               value: 'keptn'
             - name: INIT_CONTAINER_IMAGE
-              value: 'yeahservice/job-executor-service-initcontainer:0.1.1'
+              value: 'keptnsandbox/job-executor-service-initcontainer:0.1.1'
             - name: DEFAULT_RESOURCE_LIMITS_CPU
               value: "1"
             - name: DEFAULT_RESOURCE_LIMITS_MEMORY

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -20,6 +20,13 @@ spec:
           image: keptnsandbox/job-executor-service:0.1.1
           ports:
             - containerPort: 8080
+          resources:
+            limits:
+              cpu: 1
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
           env:
             - name: INIT_CONTAINER_CONFIGURATION_SERVICE_API_ENDPOINT
               value: "http://configuration-service:8080"
@@ -28,7 +35,15 @@ spec:
             - name: JOB_NAMESPACE
               value: 'keptn'
             - name: INIT_CONTAINER_IMAGE
-              value: 'keptnsandbox/job-executor-service-initcontainer:0.1.1'
+              value: 'yeahservice/job-executor-service-initcontainer:0.1.1'
+            - name: DEFAULT_RESOURCE_LIMITS_CPU
+              value: "1"
+            - name: DEFAULT_RESOURCE_LIMITS_MEMORY
+              value: "512Mi"
+            - name: DEFAULT_RESOURCE_REQUESTS_CPU
+              value: "50m"
+            - name: DEFAULT_RESOURCE_REQUESTS_MEMORY
+              value: "128Mi"
         - name: distributor
           image: keptn/distributor:0.8.3
           livenessProbe:
@@ -42,11 +57,11 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              memory: "16Mi"
-              cpu: "25m"
+              memory: "32Mi"
+              cpu: "50m"
             limits:
               memory: "128Mi"
-              cpu: "250m"
+              cpu: "500m"
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -5,3 +5,7 @@ metadata:
 data:
   job_namespace: "{{ .Release.Namespace }}"
   init_container_image: "{{ .Values.jobexecutorserviceinitcontainer.image.repository }}:{{ .Values.jobexecutorserviceinitcontainer.image.tag | default .Chart.AppVersion }}"
+  default_resource_limits_cpu: "1"
+  default_resource_limits_memory: "512Mi"
+  default_resource_requests_cpu: "50m"
+  default_resource_requests_memory: "128Mi"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -62,6 +62,26 @@ spec:
               configMapKeyRef:
                 name: job-service-config
                 key: init_container_image
+          - name: DEFAULT_RESOURCE_LIMITS_CPU
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: default_resource_limits_cpu
+          - name: DEFAULT_RESOURCE_LIMITS_MEMORY
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: default_resource_limits_memory
+          - name: DEFAULT_RESOURCE_REQUESTS_CPU
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: default_resource_requests_cpu
+          - name: DEFAULT_RESOURCE_REQUESTS_MEMORY
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: default_resource_requests_memory
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -58,15 +58,11 @@ securityContext: { }                          # Set the security context (e.g. r
 #  runAsUser: 1000
 
 resources: # Resource limits and requests
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
   requests:
-    cpu: 100m
+    cpu: 50m
     memory: 128Mi
 
 nodeSelector: { }                                # Node selector configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
 	"regexp"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -38,11 +39,12 @@ type JSONPath struct {
 
 // Task this is the actual task which can be triggered within an Action
 type Task struct {
-	Name  string   `yaml:"name"`
-	Files []string `yaml:"files"`
-	Image string   `yaml:"image"`
-	Cmd   string   `yaml:"cmd"`
-	Env   []Env    `yaml:"env"`
+	Name      string     `yaml:"name"`
+	Files     []string   `yaml:"files"`
+	Image     string     `yaml:"image"`
+	Cmd       string     `yaml:"cmd"`
+	Env       []Env      `yaml:"env"`
+	Resources *Resources `yaml:"resources"`
 }
 
 // Env value from the event which will be added as env to the job
@@ -50,6 +52,27 @@ type Env struct {
 	Name      string `yaml:"name"`
 	Value     string `yaml:"value"`
 	ValueFrom string `yaml:"valueFrom"`
+}
+
+// Resources defines the resource requirements of a task
+type Resources struct {
+	Limits   ResourceList `yaml:"limits"`
+	Requests ResourceList `yaml:"requests"`
+}
+
+// ResourceList contains resource requirement keys
+type ResourceList struct {
+	CPU    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}
+
+// JobSettings contains environment variable settings for the job
+type JobSettings struct {
+	JobNamespace                                 string
+	InitContainerConfigurationServiceAPIEndpoint string
+	KeptnAPIToken                                string
+	InitContainerImage                           string
+	DefaultResourceRequirements                  *v1.ResourceRequirements
 }
 
 // NewConfig creates a new configuration from the provided config file content

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
 	"regexp"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -64,15 +63,6 @@ type Resources struct {
 type ResourceList struct {
 	CPU    string `yaml:"cpu"`
 	Memory string `yaml:"memory"`
-}
-
-// JobSettings contains environment variable settings for the job
-type JobSettings struct {
-	JobNamespace                                 string
-	InitContainerConfigurationServiceAPIEndpoint string
-	KeptnAPIToken                                string
-	InitContainerImage                           string
-	DefaultResourceRequirements                  *v1.ResourceRequirements
 }
 
 // NewConfig creates a new configuration from the provided config file content

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,10 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"gotest.tools/assert"
 	"strings"
 	"testing"
-
-	"gotest.tools/assert"
 )
 
 const simpleConfig = `
@@ -49,6 +48,13 @@ actions:
           - name: LocustSecret
             value: locust-spine-token-exchange-dev
             valueFrom: secret
+        resources:
+          limits:
+            cpu: 1
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
 
   - name: "Run bash"
     events:
@@ -155,6 +161,13 @@ func TestComplexConfigUnmarshalling(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(config.Actions), 2)
 	assert.Equal(t, config.Actions[1].Silent, true)
+
+	assert.Assert(t, config.Actions[1].Tasks[0].Resources == nil)
+
+	assert.Equal(t, config.Actions[0].Tasks[0].Resources.Limits.CPU, "1")
+	assert.Equal(t, config.Actions[0].Tasks[0].Resources.Limits.Memory, "512Mi")
+	assert.Equal(t, config.Actions[0].Tasks[0].Resources.Requests.CPU, "50m")
+	assert.Equal(t, config.Actions[0].Tasks[0].Resources.Requests.Memory, "128Mi")
 }
 
 func TestNoApiVersion(t *testing.T) {

--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -133,8 +133,8 @@ func TestStartK8s(t *testing.T) {
 
 	k8sMock := createK8sMock(t)
 	k8sMock.EXPECT().ConnectToCluster().Times(1)
-	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1)).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName2)).Times(1)
 	k8sMock.EXPECT().DeleteK8sJob(gomock.Eq(jobName1)).Times(1)
@@ -175,8 +175,8 @@ func TestStartK8sJobSilent(t *testing.T) {
 
 	k8sMock := createK8sMock(t)
 	k8sMock.EXPECT().ConnectToCluster().Times(1)
-	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1)).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName2)).Times(1)
 	k8sMock.EXPECT().DeleteK8sJob(gomock.Eq(jobName1)).Times(1)

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -18,7 +18,7 @@ type EventHandler struct {
 	Event       cloudevents.Event
 	EventData   *keptnv2.EventData
 	ServiceName string
-	JobSettings config.JobSettings
+	JobSettings k8sutils.JobSettings
 }
 
 // HandleEvent handles all events in a generic manner

--- a/pkg/k8sutils/connect.go
+++ b/pkg/k8sutils/connect.go
@@ -18,7 +18,7 @@ type k8sImpl struct {
 // K8s is used to interact with kubernetes jobs
 type K8s interface {
 	ConnectToCluster() error
-	CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, configurationServiceURL string, configurationServiceToken string, initContainerImage string, jsonEventData interface{}) error
+	CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, jobSettings config.JobSettings, jsonEventData interface{}) error
 	DeleteK8sJob(jobName string) error
 	GetLogsOfPod(jobName string) (string, error)
 }

--- a/pkg/k8sutils/connect.go
+++ b/pkg/k8sutils/connect.go
@@ -18,7 +18,7 @@ type k8sImpl struct {
 // K8s is used to interact with kubernetes jobs
 type K8s interface {
 	ConnectToCluster() error
-	CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, jobSettings config.JobSettings, jsonEventData interface{}) error
+	CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, jobSettings JobSettings, jsonEventData interface{}) error
 	DeleteK8sJob(jobName string) error
 	GetLogsOfPod(jobName string) (string, error)
 }

--- a/pkg/k8sutils/fake/connect_mock.go
+++ b/pkg/k8sutils/fake/connect_mock.go
@@ -6,6 +6,7 @@ package fake
 
 import (
 	config "keptn-sandbox/job-executor-service/pkg/config"
+	k8sutils "keptn-sandbox/job-executor-service/pkg/k8sutils"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -50,7 +51,7 @@ func (mr *MockK8sMockRecorder) ConnectToCluster() *gomock.Call {
 }
 
 // CreateK8sJob mocks base method.
-func (m *MockK8s) CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *v0_2_0.EventData, jobSettings config.JobSettings, jsonEventData interface{}) error {
+func (m *MockK8s) CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *v0_2_0.EventData, jobSettings k8sutils.JobSettings, jsonEventData interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateK8sJob", jobName, action, task, eventData, jobSettings, jsonEventData)
 	ret0, _ := ret[0].(error)

--- a/pkg/k8sutils/fake/connect_mock.go
+++ b/pkg/k8sutils/fake/connect_mock.go
@@ -50,17 +50,17 @@ func (mr *MockK8sMockRecorder) ConnectToCluster() *gomock.Call {
 }
 
 // CreateK8sJob mocks base method.
-func (m *MockK8s) CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *v0_2_0.EventData, configurationServiceURL, configurationServiceToken, initContainerImage string, jsonEventData interface{}) error {
+func (m *MockK8s) CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *v0_2_0.EventData, jobSettings config.JobSettings, jsonEventData interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateK8sJob", jobName, action, task, eventData, configurationServiceURL, configurationServiceToken, initContainerImage, jsonEventData)
+	ret := m.ctrl.Call(m, "CreateK8sJob", jobName, action, task, eventData, jobSettings, jsonEventData)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateK8sJob indicates an expected call of CreateK8sJob.
-func (mr *MockK8sMockRecorder) CreateK8sJob(jobName, action, task, eventData, configurationServiceURL, configurationServiceToken, initContainerImage, jsonEventData interface{}) *gomock.Call {
+func (mr *MockK8sMockRecorder) CreateK8sJob(jobName, action, task, eventData, jobSettings, jsonEventData interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateK8sJob", reflect.TypeOf((*MockK8s)(nil).CreateK8sJob), jobName, action, task, eventData, configurationServiceURL, configurationServiceToken, initContainerImage, jsonEventData)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateK8sJob", reflect.TypeOf((*MockK8s)(nil).CreateK8sJob), jobName, action, task, eventData, jobSettings, jsonEventData)
 }
 
 // DeleteK8sJob mocks base method.

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -19,8 +19,17 @@ import (
 const envValueFromEvent = "event"
 const envValueFromSecret = "secret"
 
+// JobSettings contains environment variable settings for the job
+type JobSettings struct {
+	JobNamespace                                 string
+	InitContainerConfigurationServiceAPIEndpoint string
+	KeptnAPIToken                                string
+	InitContainerImage                           string
+	DefaultResourceRequirements                  *v1.ResourceRequirements
+}
+
 // CreateK8sJob creates a k8s job with the job-executor-service-initcontainer and the job image of the task and waits until the job finishes
-func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, jobSettings config.JobSettings, jsonEventData interface{}) error {
+func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, jobSettings JobSettings, jsonEventData interface{}) error {
 
 	var backOffLimit int32 = 0
 

--- a/pkg/k8sutils/resourcerequirements.go
+++ b/pkg/k8sutils/resourcerequirements.go
@@ -1,0 +1,49 @@
+package k8sutils
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// CreateResourceRequirements parses the given resource parameters and creates k8s resource requirements
+func CreateResourceRequirements(resourceLimitsCPU, resourceLimitsMemory, resourceRequestsCPU, resourceRequestsMemory string) (*v1.ResourceRequirements, error) {
+	resourceListLimits, err := createResourceList(resourceLimitsCPU, resourceLimitsMemory)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse resource limits requirement: %v", err.Error())
+	}
+
+	resourceListRequests, err := createResourceList(resourceRequestsCPU, resourceRequestsMemory)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse resource requests requirement: %v", err.Error())
+	}
+
+	resourceRequirements := v1.ResourceRequirements{
+		Limits:   resourceListLimits,
+		Requests: resourceListRequests,
+	}
+
+	return &resourceRequirements, nil
+}
+
+func createResourceList(cpu, memory string) (v1.ResourceList, error) {
+	res := v1.ResourceList{}
+
+	if cpu != "" {
+		cpuQuantity, err := resource.ParseQuantity(cpu)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse cpu quantity '%v': %v", cpu, err.Error())
+		}
+		res[v1.ResourceCPU] = cpuQuantity
+	}
+
+	if memory != "" {
+		memoryQuantity, err := resource.ParseQuantity(memory)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse memory quantity '%v': %v", memory, err.Error())
+		}
+		res[v1.ResourceMemory] = memoryQuantity
+	}
+
+	return res, nil
+}

--- a/pkg/k8sutils/resourcerequirements_test.go
+++ b/pkg/k8sutils/resourcerequirements_test.go
@@ -1,0 +1,53 @@
+package k8sutils
+
+import (
+	"gotest.tools/assert"
+	"testing"
+)
+
+const (
+	resourceLimitsCPU      = "1Ei"
+	resourceLimitsMemory   = "512Mi"
+	resourceRequestsCPU    = "50m"
+	resourceRequestsMemory = "128Mi"
+)
+
+func TestCreateResourceRequirements_Valid(t *testing.T) {
+	resourceRequirements, err := CreateResourceRequirements(
+		resourceLimitsCPU,
+		resourceLimitsMemory,
+		resourceRequestsCPU,
+		resourceRequestsMemory,
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, resourceRequirements.Limits.Cpu().String(), resourceLimitsCPU)
+	assert.Equal(t, resourceRequirements.Limits.Memory().String(), resourceLimitsMemory)
+	assert.Equal(t, resourceRequirements.Requests.Cpu().String(), resourceRequestsCPU)
+	assert.Equal(t, resourceRequirements.Requests.Memory().String(), resourceRequestsMemory)
+}
+
+func TestCreateResourceRequirements_Partial(t *testing.T) {
+	resourceRequirements, err := CreateResourceRequirements(
+		resourceLimitsCPU,
+		"",
+		"",
+		resourceRequestsMemory,
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, resourceRequirements.Limits.Cpu().String(), resourceLimitsCPU)
+	assert.Assert(t, resourceRequirements.Limits.Memory().IsZero())
+	assert.Assert(t, resourceRequirements.Requests.Cpu().IsZero())
+	assert.Equal(t, resourceRequirements.Requests.Memory().String(), resourceRequestsMemory)
+}
+
+func TestCreateResourceRequirements_Invalid(t *testing.T) {
+	// according to the k8s regex this is valid but the quantity suffix parsing afterwards should fail
+	var resourceLimitsCPU = "1KeinEiKummGeGimmeEinEi"
+	_, err := CreateResourceRequirements(
+		resourceLimitsCPU,
+		resourceLimitsMemory,
+		resourceRequestsCPU,
+		resourceRequestsMemory,
+	)
+	assert.ErrorContains(t, err, "unable to parse resource limits requirement: unable to parse cpu quantity '1KeinEiKummGeGimmeEinEi'")
+}


### PR DESCRIPTION
### Set resource quotas for the service and distributor everywhere to the same values

Service:
```yaml
limits:
  cpu: 1
  memory: 512Mi
requests:
  cpu: 50m
  memory: 128Mi
```

Distributor:
```yaml
requests:
  memory: "32Mi"
  cpu: "50m"
limits:
  memory: "128Mi"
  cpu: "500m"
```

### Resource quotas for jobs

The `initcontainer` and the `job` container will use the default resource quotas defined as environment variables. They
can be set in [`deploy/service.yaml`](deploy/service.yaml):

```yaml
- name: DEFAULT_RESOURCE_LIMITS_CPU
  value: "1"
- name: DEFAULT_RESOURCE_LIMITS_MEMORY
  value: "512Mi"
- name: DEFAULT_RESOURCE_REQUESTS_CPU
  value: "50m"
- name: DEFAULT_RESOURCE_REQUESTS_MEMORY
  value: "128Mi"
```

or for helm in [`helm/templates/configmap.yaml`](helm/templates/configmap.yaml):

```yaml
default_resource_limits_cpu: "1"
default_resource_limits_memory: "512Mi"
default_resource_requests_cpu: "50m"
default_resource_requests_memory: "128Mi"
```

The default resource quotas can be easily overwritten for each task. Add the following block to the configuration on
task level:

```yaml
tasks:
  - name: "Run locust smoke tests"
    ...
    resources:
      limits:
        cpu: 1
        memory: 512Mi
      requests:
        cpu: 50m
        memory: 128Mi
```

Now each job that gets spawned for the task will have the configured resource quotas. There is no need to specify all
values, as long as the configuration makes sense for kubernetes. E.g. the following configuration

```yaml
tasks:
  - name: "Run locust smoke tests"
    ...
    resources:
      limits:
        cpu: 1
      requests:
        cpu: 50m
```

would result in resource quotas for `cpu`, but in none for `memory`. If the `resources` block is present
(even if empty), all default resource quotas are ignored for this task.

### Technical details

* Default resource quotas are parsed on service startup to ensure everything is valid when jobs are spawned
* Environment variables and the default resource quotas are now handled by a struct `JobSettings`, defined in [`pkg/config/config.go`](pkg/config/config.go). Results in lower amount of parameters and easier life for some functions. Also it is defined in  [`pkg/config/config.go`](pkg/config/config.go) and not in [`pkg/eventhandler/eventhandler.go`](pkg/eventhandler/eventhandler.go) because otherwise it would result in cyclic depedencies between [`pkg/eventhandler/eventhandler.go`](pkg/eventhandler/eventhandler.go) and [`pkg/k8utils/job.go`](pkg/k8utils/job.go) 