### PR TITLE
Extend command to allow declaration of arrays and and args to be passed through to the k8s job

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Just put a file into the keptn git repository (in folder `<service>/job/config.y
 * the events for which they should be triggered.
 
 ```yaml
-apiVersion: v1
+apiVersion: v2
 actions:
   - name: "Run locust"
     events:
@@ -46,7 +46,15 @@ actions:
           - locust/import.py
           - locust/locust.conf
         image: "locustio/locust"
-        cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
+        cmd:
+          - locust
+        args:
+          - '--config'
+          - /keptn/locust/locust.conf
+          - '-f'
+          - /keptn/locust/basic.py
+          - '--host'
+          - $(HOST)
         env:
           - name: HOST
             value: "$.data.deployment.deploymentURIsLocal[0]"
@@ -113,7 +121,15 @@ tasks:
       - locust/import.py
       - locust/locust.conf
     image: "locustio/locust"
-    cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
+    cmd:
+      - locust
+    args:
+      - '--config'
+      - /keptn/locust/locust.conf
+      - '-f'
+      - /keptn/locust/basic.py
+      - '--host'
+      - $(HOST)
 ```
 
 It contains the tasks which should be executed as Kubernetes job. The service schedules a different job for each of
@@ -135,7 +151,15 @@ The following environment variable has the name `HOST`, and the value is whateve
 jsonpath `$.data.deployment.deploymentURIsLocal[0]` resolves to.
 
 ```yaml
-cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
+cmd:
+  - locust
+args:
+  - '--config'
+  - /keptn/locust/locust.conf
+  - '-f'
+  - /keptn/locust/basic.py
+  - '--host'
+  - $(HOST)
 env:
   - name: HOST
     value: "$.data.deployment.deploymentURIsLocal[0]"
@@ -184,7 +208,15 @@ The following configuration looks up a kubernetes secret with the name `locust-s
 secret will be available as separate environment variables in the job.
 
 ```yaml
-cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/$(FILE) --host $(HOST)"
+cmd:
+  - locust
+args:
+  - '--config'
+  - /keptn/locust/locust.conf
+  - '-f'
+  - /keptn/locust/$(FILE)
+  - '--host'
+  - $(HOST)
 env:
   - name: locust-secret
     valueFrom: secret
@@ -234,7 +266,12 @@ When using these files in your container command, please make sure to reference 
 E.g.:
 
 ```yaml
-cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py"
+cmd:
+  - locust
+  - '--config'
+  - /keptn/locust/locust.conf
+  - '-f'
+  - /keptn/locust/basic.py
 ```
 
 ### Silent mode
@@ -328,11 +365,12 @@ The credits of this service heavily go to @thschue and @yeahservice who original
 
 ## Compatibility Matrix
 
-| Keptn Version    | [Job-Executor-Service Docker Image](https://hub.docker.com/r/keptnsandbox/job-executor-service/tags) |
-|:----------------:|:----------------------------------------:|
-|       0.8.3      | keptnsandbox/job-executor-service:0.1.0  |
-|       0.8.3      | keptnsandbox/job-executor-service:0.1.1  |
-|       0.8.4      | keptnsandbox/job-executor-service:0.1.2  |
+| Keptn Version | [Job-Executor-Service Docker Image](https://hub.docker.com/r/keptnsandbox/job-executor-service/tags) | Config version |
+| :-----------: | :--------------------------------------------------------------------------------------------------: | :------------: |
+|     0.8.3     |                               keptnsandbox/job-executor-service:0.1.0                                |       -        |
+|     0.8.3     |                               keptnsandbox/job-executor-service:0.1.1                                |       -        |
+|     0.8.4     |                               keptnsandbox/job-executor-service:0.1.2                                |       v1       |
+|     0.8.4     |                               keptnsandbox/job-executor-service:0.1.3                                |       v2       |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ E.g.:
 ```yaml
 cmd:
   - locust
+args:
   - '--config'
   - /keptn/locust/locust.conf
   - '-f'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PaesslerAG/jsonpath"
 )
 
-const supportedAPIVersion = "v1"
+const supportedAPIVersion = "v2"
 
 // Config contains the configuration of the job-executor-service (job/config.yaml)
 type Config struct {
@@ -41,7 +41,8 @@ type Task struct {
 	Name      string     `yaml:"name"`
 	Files     []string   `yaml:"files"`
 	Image     string     `yaml:"image"`
-	Cmd       string     `yaml:"cmd"`
+	Cmd       []string   `yaml:"cmd"`
+	Args      []string   `yaml:"args"`
 	Env       []Env      `yaml:"env"`
 	Resources *Resources `yaml:"resources"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,6 +24,7 @@ actions:
         image: "locustio/locust"
         cmd:
           - locust
+        args:
           - '-f'
           - /keptn/locust/locustfile.py
 `

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -169,10 +169,11 @@ func TestSimpleConfigUnmarshalling(t *testing.T) {
 	assert.Equal(t, len(config.Actions), 1)
 	assert.Equal(t, config.Actions[0].Silent, false)
 
-	assert.Equal(t, len(config.Actions[0].Tasks[0].Cmd), 3)
+	assert.Equal(t, len(config.Actions[0].Tasks[0].Cmd), 1)
 	assert.Equal(t, config.Actions[0].Tasks[0].Cmd[0], "locust")
-	assert.Equal(t, config.Actions[0].Tasks[0].Cmd[1], "-f")
-	assert.Equal(t, config.Actions[0].Tasks[0].Cmd[2], "/keptn/locust/locustfile.py")
+	assert.Equal(t, len(config.Actions[0].Tasks[0].Args), 2)
+	assert.Equal(t, config.Actions[0].Tasks[0].Args[0], "-f")
+	assert.Equal(t, config.Actions[0].Tasks[0].Args[1], "/keptn/locust/locustfile.py")
 }
 
 func TestComplexConfigUnmarshalling(t *testing.T) {

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -35,6 +35,7 @@ func (eh *EventHandler) HandleEvent() error {
 
 	resource, err := eh.Keptn.GetKeptnResource("job/config.yaml")
 	if err != nil {
+		// TODO we can't send a finished event with the error here, utilize the uniform logging instead?
 		log.Printf("Could not find config for job-executor-service: %s", err.Error())
 		return err
 	}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const simpleConfig = `
-apiVersion: v1
+apiVersion: v2
 actions:
   - name: "action"
     events:
@@ -25,7 +25,10 @@ actions:
           - /helm/values.yaml
           - locust
         image: "locustio/locust"
-        cmd: "locust -f /keptn/locust/basic.py"
+        cmd:
+          - locust
+          - '-f'
+          - /keptn/locust/basic.py
 `
 
 const pythonFile = `

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -27,6 +27,7 @@ actions:
         image: "locustio/locust"
         cmd:
           - locust
+        args:
           - '-f'
           - /keptn/locust/basic.py
 `

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/PaesslerAG/jsonpath"
 	"keptn-sandbox/job-executor-service/pkg/config"
-	"strings"
 	"time"
 
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -81,7 +80,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 				Spec: v1.PodSpec{
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsUser:    convert(1000),
-						RunAsGroup:   convert(3000),
+						RunAsGroup:   convert(2000),
 						FSGroup:      convert(2000),
 						RunAsNonRoot: &runAsNonRoot,
 					},
@@ -133,7 +132,8 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 						{
 							Name:    jobName,
 							Image:   task.Image,
-							Command: strings.Split(task.Cmd, " "),
+							Command: task.Cmd,
+							Args:    task.Args,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      jobVolumeName,

--- a/releasenotes/releasenotes_V0.1.2.md
+++ b/releasenotes/releasenotes_V0.1.2.md
@@ -11,3 +11,4 @@ Compatible with Keptn 0.8.4
 ## Fixed Issues
 
 ## Known Limitations
+* Uniform registration for remote execution planes over https doesn't work

--- a/test-data/config.yaml
+++ b/test-data/config.yaml
@@ -1,31 +1,40 @@
 apiVersion: v1
 actions:
-  - name: "Run locust"
+  - name: Run locust
     events:
-      - name: "sh.keptn.event.test.triggered"
+      - name: sh.keptn.event.test.triggered
         jsonpath:
-          property: "$.data.test.teststrategy"
-          match: "locust"
+          property: $.data.test.teststrategy
+          match: locust
     tasks:
-      - name: "Run locust smoke tests"
+      - name: Run locust smoke tests
         files:
           - locust/basic.py
           - locust/import.py
-        image: "locustio/locust"
-        cmd: "locust -f /keptn/locust/basic.py"
-
-  - name: "Run Bash"
+        image: locustio/locust
+        cmd:
+          - locust
+        args:
+          - '-f'
+          - /keptn/locust/basic.py
+  - name: Run Bash
     events:
-      - name: "sh.keptn.event.action.triggered"
+      - name: sh.keptn.event.action.triggered
         jsonpath:
-          property: "$.data.action.action"
-          match: "hello"
+          property: $.data.action.action
+          match: hello
     tasks:
-      - name: "Run static world"
-        image: "bash"
-        cmd: "echo static"
-      - name: "Run hello world"
+      - name: Run static world
+        image: bash
+        cmd:
+          - echo
+        args:
+          - static
+      - name: Run hello world
         files:
           - hello/hello-world.txt
-        image: "bash"
-        cmd: "cat /keptn/hello/hello-world.txt | echo"
+        image: bash
+        cmd:
+          - cat
+        args:
+          - /keptn/hello/hello-world.txt


### PR DESCRIPTION
With the current way it is not really possible to write more complex commands, since everything gets just splitted by white spaces and added as command to the k8s job, which can lead to issues with chained commands `&&`. Let users decide how exactly they want to split commands and also allow definition of args, passed through to the k8s job.

Current declaration:
```yaml
cmd: "locust --config /keptn/locust/locust.conf -f /keptn/locust/basic.py --host $(HOST)"
```

New declaration:
```yaml
cmd:
  - locust
args:
  - '--config'
  - /keptn/locust/locust.conf
  - '-f'
  - /keptn/locust/basic.py
  - '--host'
  - $(HOST)
```

Bumped config version to `v2` because it is not backwards compatible.