### PR TITLE
fix labels referenced by distributor env vars

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "job-executor-service.selectorLabels" . | nindent 8 }}
+        {{- include "job-executor-service.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -70,7 +70,3 @@ nodeSelector: { }                                # Node selector configuration
 tolerations: [ ]                                 # Tolerations for the pods
 
 affinity: { }                                    # Affinity rules
-
-# TODO resource quotas of job
-
-


### PR DESCRIPTION
The distributor references the following fields from labels, but they are not present.
```yaml
            - name: VERSION
              valueFrom:
                fieldRef:
                  fieldPath: metadata.labels['app.kubernetes.io/version']
            - name: K8S_DEPLOYMENT_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.labels['app.kubernetes.io/name']
```

Switch the labels from `selectorLabels` to `labels` which includes the missing labels.