### PR TITLE
Add simple cli tool that parses a given job config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,7 +119,6 @@ jobs:
         run: go test -coverprofile=coverage.txt -covermode=atomic -v ./...
         working-directory: .
 
-
   ############################################################################
   # Build Docker Image                                                      #
   ############################################################################

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  lint_build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run make
+        run: make -C lint
+      - name: Upload Linux
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/job-lint-linux-amd64
+          asset_name: job-lint-linux-amd64
+          asset_content_type: binary/octet-stream
+      - name: Upload Windows
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/job-lint-windows-amd64
+          asset_name: job-lint-windows-amd64
+          asset_content_type: binary/octet-stream
+      - name: Upload Darwin
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/job-lint-darwin-amd64
+          asset_name: job-lint-darwin-amd64
+          asset_content_type: binary/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin
 
 # Test binary, build with `go test -c`
 *.test

--- a/lint/Makefile
+++ b/lint/Makefile
@@ -1,0 +1,5 @@
+compile:
+	echo "Compiling for every OS and Platform"
+	GOOS=linux GOARCH=amd64 go build -o ../bin/job-lint-linux-amd64 .
+	GOOS=windows GOARCH=amd64 go build -o ../bin/job-lint-windows-amd64 .
+	GOOS=darwin GOARCH=amd64 go build -o ../bin/job-lint-darwin-amd64 .

--- a/lint/main.go
+++ b/lint/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io/ioutil"
+	"keptn-sandbox/job-executor-service/pkg/config"
+	"log"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) != 1 {
+		log.Fatal("exactly one argument needed")
+	}
+
+	jobConfigName := args[0]
+	jobConfig, err := ioutil.ReadFile(jobConfigName)
+	if err != nil {
+		log.Fatalf("could not read job config %v: %v", jobConfigName, err)
+	}
+
+	_, err = config.NewConfig(jobConfig)
+	if err != nil {
+		log.Fatalf("error parsing %v: %v", string(jobConfig), err)
+	}
+
+	log.Printf("config %v is valid", jobConfigName)
+}

--- a/test-data/config.yaml
+++ b/test-data/config.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 actions:
   - name: Run locust
     events:


### PR DESCRIPTION
* Add github actions for building respective binaries after new release creation and adds them as assets (not fully tested but let's see what happens on the next release :bomb:)