### PR TITLE
Add new env variable source `string`

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,34 @@ metadata:
   namespace: keptn
 ```
 
+#### From string literal
+
+It sometimes makes sense to provide a static string value as an environment
+variable. This can be done by specifying a `string` as the `valueFrom` value.
+The value of the environment variable can then be specified by the `value`
+property.
+
+Here an example
+
+```yaml
+cmd:
+  - locust
+args:
+  - '--config'
+  - /keptn/locust/locust.conf
+  - '-f'
+  - /keptn/locust/$(FILE)
+  - '--host'
+  - $(HOST)
+env:
+  - name: DATA_DIR
+    valueFrom: string
+    value: /tmp/data
+```
+
+This makes the `DATA_DIR` env variable with the value `/tmp/data`
+available to the cmd.
+
 ### File Handling
 
 Single files or all files in a directory can be added to your running tasks by specifying them in the `files` section of

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -17,6 +17,7 @@ import (
 
 const envValueFromEvent = "event"
 const envValueFromSecret = "secret"
+const envValueFromString = "string"
 
 // JobSettings contains environment variable settings for the job
 type JobSettings struct {
@@ -222,6 +223,8 @@ func (k8s *k8sImpl) prepareJobEnv(task config.Task, eventData *keptnv2.EventData
 			generatedEnv, err = generateEnvFromEvent(env, jsonEventData)
 		case envValueFromSecret:
 			generatedEnv, err = k8s.generateEnvFromSecret(env)
+		case envValueFromString:
+			generatedEnv = generateEnvFromString(env)
 		default:
 			return nil, fmt.Errorf("could not add env with name %v, unknown valueFrom %v", env.Name, env.ValueFrom)
 		}
@@ -265,6 +268,15 @@ func generateEnvFromEvent(env config.Env, jsonEventData interface{}) ([]v1.EnvVa
 	}
 
 	return generatedEnv, nil
+}
+
+func generateEnvFromString(env config.Env) []v1.EnvVar {
+	return []v1.EnvVar{
+		{
+			Name:  env.Name,
+			Value: env.Value,
+		},
+	}
 }
 
 func (k8s *k8sImpl) generateEnvFromSecret(env config.Env) ([]v1.EnvVar, error) {


### PR DESCRIPTION
There is now a new env variable source `string` which allows you to
specify the value of an env var, by providing the `value` property.

This fixes #34