### PR TITLE
Make poll duration for single tasks configureable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ actions:
 
 ### Specifying the working directory
 
-Since all files are hosted by default under `/keptn` and some tools only operate on the current
-working directory, it is also possible to switch the working directory of the container.
-This can be achieved by setting the `workingDirectory` property in a task object.
+Since all files are hosted by default under `/keptn` and some tools only operate on the current working directory, it is
+also possible to switch the working directory of the container. This can be achieved by setting the `workingDirectory`
+property in a task object.
 
 Here an example:
+
 ```yaml
 apiVersion: v2
 actions:
@@ -266,9 +267,8 @@ metadata:
 
 #### From string literal
 
-It sometimes makes sense to provide a static string value as an environment
-variable. This can be done by specifying a `string` as the `valueFrom` value.
-The value of the environment variable can then be specified by the `value`
+It sometimes makes sense to provide a static string value as an environment variable. This can be done by specifying
+a `string` as the `valueFrom` value. The value of the environment variable can then be specified by the `value`
 property.
 
 Here an example
@@ -396,6 +396,19 @@ tasks:
 
 would result in resource quotas for `cpu`, but in none for `memory`. If the `resources` block is present
 (even if empty), all default resource quotas are ignored for this task.
+
+### Poll duration for jobs
+
+The default settings allow a job to run for 5 min until the job executor service cancels the task execution. The default
+value can be overwritten for each task and is declared as seconds. The setting below would result in a poll duration of
+20 minutes for this specific task:
+
+```yaml
+tasks:
+  - name: "Run locust smoke tests"
+    ...
+    maxPollDuration: 1200
+```
 
 ### Remote Control Plane
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,14 +38,15 @@ type JSONPath struct {
 
 // Task this is the actual task which can be triggered within an Action
 type Task struct {
-	Name       string     `yaml:"name"`
-	Files      []string   `yaml:"files"`
-	Image      string     `yaml:"image"`
-	Cmd        []string   `yaml:"cmd"`
-	Args       []string   `yaml:"args"`
-	Env        []Env      `yaml:"env"`
-	Resources  *Resources `yaml:"resources"`
-	WorkingDir string     `yaml:"workingDir"`
+	Name            string     `yaml:"name"`
+	Files           []string   `yaml:"files"`
+	Image           string     `yaml:"image"`
+	Cmd             []string   `yaml:"cmd"`
+	Args            []string   `yaml:"args"`
+	Env             []Env      `yaml:"env"`
+	Resources       *Resources `yaml:"resources"`
+	WorkingDir      string     `yaml:"workingDir"`
+	MaxPollDuration *int       `yaml:"maxPollDuration"`
 }
 
 // Env value from the event which will be added as env to the job

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,6 +66,7 @@ actions:
           requests:
             cpu: 50m
             memory: 128Mi
+        maxPollDuration: 1000
 
   - name: "Run bash"
     events:
@@ -200,6 +201,7 @@ func TestComplexConfigUnmarshalling(t *testing.T) {
 	assert.Equal(t, config.Actions[0].Tasks[0].Args[1], "/keptn/locust/locustfile.py")
 	assert.Equal(t, config.Actions[0].Tasks[0].Args[2], "--host")
 	assert.Equal(t, config.Actions[0].Tasks[0].Args[3], "$(HOST)")
+	assert.Equal(t, *config.Actions[0].Tasks[0].MaxPollDuration, 1000)
 }
 
 func TestNoApiVersion(t *testing.T) {

--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -119,11 +119,13 @@ func TestStartK8s(t *testing.T) {
 	}
 	eventPayloadAsInterface, _ := eh.createEventPayloadAsInterface()
 
+	maxPollDuration := 1006
 	action := config.Action{
 		Name: "Run locust",
 		Tasks: []config.Task{
 			{
-				Name: "Run locust smoked ham tests",
+				Name:            "Run locust smoked ham tests",
+				MaxPollDuration: &maxPollDuration,
 			},
 			{
 				Name: "Run locust healthy snack tests",
@@ -137,7 +139,8 @@ func TestStartK8s(t *testing.T) {
 		gomock.Any()).Times(1)
 	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Any()).Times(2)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), 202, 5).Times(1)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName2), 60, 5).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1)).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName2)).Times(1)
 	k8sMock.EXPECT().DeleteK8sJob(gomock.Eq(jobName1)).Times(1)
@@ -182,7 +185,7 @@ func TestStartK8sJobSilent(t *testing.T) {
 		gomock.Any()).Times(1)
 	k8sMock.EXPECT().CreateK8sJob(gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Any()).Times(2)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Any(), 60, 5).Times(2)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1)).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName2)).Times(1)
 	k8sMock.EXPECT().DeleteK8sJob(gomock.Eq(jobName1)).Times(1)

--- a/pkg/k8sutils/connect.go
+++ b/pkg/k8sutils/connect.go
@@ -20,7 +20,7 @@ type K8s interface {
 	ConnectToCluster() error
 	CreateK8sJob(jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData,
 		jobSettings JobSettings, jsonEventData interface{}) error
-	AwaitK8sJobDone(jobName string) error
+	AwaitK8sJobDone(jobName string, maxPollDuration int, pollIntervalInSeconds int) error
 	DeleteK8sJob(jobName string) error
 	GetLogsOfPod(jobName string) (string, error)
 }

--- a/pkg/k8sutils/fake/connect_mock.go
+++ b/pkg/k8sutils/fake/connect_mock.go
@@ -37,17 +37,17 @@ func (m *MockK8s) EXPECT() *MockK8sMockRecorder {
 }
 
 // AwaitK8sJobDone mocks base method.
-func (m *MockK8s) AwaitK8sJobDone(jobName string) error {
+func (m *MockK8s) AwaitK8sJobDone(jobName string, maxPollDuration, pollIntervalInSeconds int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AwaitK8sJobDone", jobName)
+	ret := m.ctrl.Call(m, "AwaitK8sJobDone", jobName, maxPollDuration, pollIntervalInSeconds)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AwaitK8sJobDone indicates an expected call of AwaitK8sJobDone.
-func (mr *MockK8sMockRecorder) AwaitK8sJobDone(jobName interface{}) *gomock.Call {
+func (mr *MockK8sMockRecorder) AwaitK8sJobDone(jobName, maxPollDuration, pollIntervalInSeconds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitK8sJobDone", reflect.TypeOf((*MockK8s)(nil).AwaitK8sJobDone), jobName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitK8sJobDone", reflect.TypeOf((*MockK8s)(nil).AwaitK8sJobDone), jobName, maxPollDuration, pollIntervalInSeconds)
 }
 
 // ConnectToCluster mocks base method.

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -174,13 +174,9 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 	return nil
 }
 
-func (k8s *k8sImpl) AwaitK8sJobDone(jobName string) error {
+func (k8s *k8sImpl) AwaitK8sJobDone(jobName string, maxPollCount int, pollIntervalInSeconds int) error {
 	jobs := k8s.clientset.BatchV1().Jobs(k8s.namespace)
 
-	// TODO timeout from outside
-	// 60 times with 5 seconds wait time => 5 minutes
-	const maxPollCount = 60
-	const pollIntervalInSeconds = 5
 	currentPollCount := 0
 
 	for {
@@ -208,7 +204,7 @@ func (k8s *k8sImpl) AwaitK8sJobDone(jobName string) error {
 			}
 		}
 
-		time.Sleep(pollIntervalInSeconds * time.Second)
+		time.Sleep(time.Duration(pollIntervalInSeconds) * time.Second)
 	}
 }
 


### PR DESCRIPTION
The default settings allow a job to run for 5 min until the job executor service cancels the task execution. The default
value can be overwritten for each task and is declared as seconds. The setting below would result in a poll duration of
20 minutes for this specific task:

```yaml
tasks:
  - name: "Run locust smoke tests"
    ...
    maxPollDuration: 1200
```

Internally we use 5 seconds between each poll attempt. So the above setting would result in 240 poll attempts.
