### PR TITLE
Fix workdir documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ actions:
 ### Specifying the working directory
 
 Since all files are hosted by default under `/keptn` and some tools only operate on the current working directory, it is
-also possible to switch the working directory of the container. This can be achieved by setting the `workingDirectory`
+also possible to switch the working directory of the container. This can be achieved by setting the `workingDir`
 property in a task object.
 
 Here an example:
@@ -111,7 +111,7 @@ actions:
     tasks:
       - name: "Show files in bin"
         image: "alpine"
-        workingDirectory: "/bin"
+        workingDir: "/bin"
         cmd:
           - ls
 ```


### PR DESCRIPTION
The `workingDirectory` parameter mentioned in the `README.md` file does not match the `workingDir` name defined in the [code](https://github.com/keptn-sandbox/job-executor-service/blob/main/pkg/config/config.go#L48) and therefore throws an error when used:

```
2021/07/20 15:11:48 Could not parse config: yaml: unmarshal errors: line 19: field workingDirectory not found in type config.Task
```