### PR TITLE
Event data formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,27 @@ In the above example the json path for `HOST` would resolve into `https://keptn.
 }
 ```
 
+The Job executor service also allows you to format the event data in different formats including `JSON` and `YAML` using the `as` keyword. This can be useful when working with the whole event or an object with multiple fields.
+
+```yaml
+cmd:
+  - locust
+args:
+  - '--config'
+  - /keptn/locust/locust.conf
+  - '-f'
+  - /keptn/locust/basic.py
+  - '--host'
+  - $(HOST)
+env:
+  - name: EVENT
+    value: "$"
+    valueFrom: event
+    as: json
+```
+
+If the `as` keyword is omitted the job executor defaults to `string` for a single value and `JSON` for a `map` type.
+
 #### From Kubernetes Secrets
 
 The following configuration looks up a kubernetes secret with the name `locust-secret` and all key/value pairs of the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,9 +51,10 @@ type Task struct {
 
 // Env value from the event which will be added as env to the job
 type Env struct {
-	Name      string `yaml:"name"`
-	Value     string `yaml:"value"`
-	ValueFrom string `yaml:"valueFrom"`
+	Name       string `yaml:"name"`
+	Value      string `yaml:"value"`
+	ValueFrom  string `yaml:"valueFrom"`
+	Formatting string `yaml:"as"`
 }
 
 // Resources defines the resource requirements of a task

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -98,6 +98,8 @@ func (eh *EventHandler) createEventPayloadAsInterface() (map[string]interface{},
 	eventAsInterface["time"] = eh.Event.Time()
 	eventAsInterface["source"] = eh.Event.Source()
 	eventAsInterface["data"] = eventDataAsInterface
+	eventAsInterface["specversion"] = eh.Event.SpecVersion()
+	eventAsInterface["type"] = eh.Event.Type()
 
 	return eventAsInterface, nil
 }

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -2,10 +2,13 @@ package k8sutils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/PaesslerAG/jsonpath"
 	"keptn-sandbox/job-executor-service/pkg/config"
+	"reflect"
 	"time"
+	"log"
 
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
@@ -264,6 +267,26 @@ func generateEnvFromEvent(env config.Env, jsonEventData interface{}) ([]v1.EnvVa
 	if err != nil {
 		return nil, fmt.Errorf("could not add env with name %v, value %v, valueFrom %v: %v", env.Name, env.Value, env.ValueFrom, err)
 	}
+
+	if reflect.ValueOf(value).Kind() == reflect.Map {
+		log.Println("Values is map")
+
+		jsonString, err := json.Marshal(value)
+
+		if err != nil {
+			log.Printf("Error converting event to JSON: %e",err)
+		}
+
+		value = string(jsonString[:])
+	} 
+
+	jsonString, err := json.Marshal(value)
+
+	if err != nil {
+		fmt.Printf("Error converting event to JSON: %e",err)
+	}
+	fmt.Printf("Converted Event: %s \n", jsonString)
+
 
 	generatedEnv := []v1.EnvVar{
 		{


### PR DESCRIPTION
Allowing the user to specify `JSON` and `YAML` as formats for the environment event data. 

```
- name: EVENT
  value: "$"
  valueFrom: event
  as: json
```

If the `as` field is left empty the event will either be passed as JSON if it is a map or as a string if it is a single value.

```
- name: EVENT
  value: "$"
  valueFrom: event
```

## Fixes
#59 