### PR TITLE
feat: Add start and end event metadata for test finished events

### DIFF
--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -247,8 +247,11 @@ func TestStartK8s_TestFinishedEvent(t *testing.T) {
 		if cloudEvent.Type() == keptnv2.GetFinishedEventType(keptnv2.TestTaskName) {
 			eventData := &keptnv2.TestFinishedEventData{}
 			cloudEvent.DataAs(eventData)
+			toime := time.Now()
+			zone, offset := toime.Zone()
+			fmt.Println(zone, offset)
 
-			dateLayout := "2006-01-02T15:04:05+02:00"
+			dateLayout := "2006-01-02T15:04:05Z"
 			_, err := time.Parse(dateLayout, eventData.Test.Start)
 			assert.NilError(t, err)
 			_, err = time.Parse(dateLayout, eventData.Test.End)

--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -235,6 +235,11 @@ func TestStartK8s_TestFinishedEvent(t *testing.T) {
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1), gomock.Any()).Times(1)
 	k8sMock.EXPECT().DeleteK8sJob(gomock.Eq(jobName1), gomock.Any()).Times(1)
 
+	// set the global timezone for testing
+	local, err := time.LoadLocation("UTC")
+	assert.NilError(t, err)
+	time.Local = local
+
 	eh.startK8sJob(k8sMock, &action, eventPayloadAsInterface)
 
 	err = fakeEventSender.AssertSentEventTypes([]string{
@@ -247,9 +252,6 @@ func TestStartK8s_TestFinishedEvent(t *testing.T) {
 		if cloudEvent.Type() == keptnv2.GetFinishedEventType(keptnv2.TestTaskName) {
 			eventData := &keptnv2.TestFinishedEventData{}
 			cloudEvent.DataAs(eventData)
-			toime := time.Now()
-			zone, offset := toime.Zone()
-			fmt.Println(zone, offset)
 
 			dateLayout := "2006-01-02T15:04:05Z"
 			_, err := time.Parse(dateLayout, eventData.Test.Start)

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"math"
 	"strconv"
+	"strings"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2" // make sure to use v2 cloudevents here
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -32,6 +34,11 @@ type jobLogs struct {
 	logs string
 }
 
+type dataForFinishedEvent struct {
+	start time.Time
+	end time.Time
+}
+
 // HandleEvent handles all events in a generic manner
 func (eh *EventHandler) HandleEvent() error {
 
@@ -53,7 +60,7 @@ func (eh *EventHandler) HandleEvent() error {
 			if err != nil {
 				log.Printf("Error while sending started event: %s\n", err.Error())
 			}
-			sendTaskFinishedEvent(eh.Keptn, eh.ServiceName, nil)
+			sendTaskFinishedEvent(eh.Keptn, eh.ServiceName, nil, dataForFinishedEvent{})
 		}
 
 		return err
@@ -124,6 +131,9 @@ func (eh *EventHandler) startK8sJob(k8s k8sutils.K8s, action *config.Action, jso
 	}
 
 	allJobLogs := []jobLogs{}
+	additionalFinishedEventData := dataForFinishedEvent{
+		start: time.Now(),
+	}
 
 	for index, task := range action.Tasks {
 		log.Printf("Starting task %s/%s: '%s' ...", strconv.Itoa(index+1), strconv.Itoa(len(action.Tasks)), task.Name)
@@ -179,10 +189,12 @@ func (eh *EventHandler) startK8sJob(k8s k8sutils.K8s, action *config.Action, jso
 		})
 	}
 
+	additionalFinishedEventData.end = time.Now()
+
 	log.Printf("Successfully finished processing of event: %s\n", eh.Event.ID())
 
 	if !action.Silent {
-		sendTaskFinishedEvent(eh.Keptn, eh.ServiceName, allJobLogs)
+		sendTaskFinishedEvent(eh.Keptn, eh.ServiceName, allJobLogs, additionalFinishedEventData)
 	}
 }
 
@@ -206,22 +218,41 @@ func sendTaskFailedEvent(myKeptn *keptnv2.Keptn, jobName string, serviceName str
 	}
 }
 
-func sendTaskFinishedEvent(myKeptn *keptnv2.Keptn, serviceName string, jobLogs []jobLogs) {
+func sendTaskFinishedEvent(myKeptn *keptnv2.Keptn, serviceName string, jobLogs []jobLogs, data dataForFinishedEvent) {
 	var message string
 
 	for _, jobLogs := range jobLogs {
 		message += fmt.Sprintf("Job %s finished successfully!\n\nLogs:\n%s\n\n", jobLogs.name, jobLogs.logs)
 	}
 
-	_, err := myKeptn.SendTaskFinishedEvent(&keptnv2.EventData{
+	eventData := &keptnv2.EventData{
 
 		Status:  keptnv2.StatusSucceeded,
 		Result:  keptnv2.ResultPass,
 		Message: message,
-	}, serviceName)
+	}
+
+	var err error
+
+	if isTestEvent(myKeptn.CloudEvent.Type()) && !data.start.IsZero() && !data.end.IsZero() {
+		event := &keptnv2.TestFinishedEventData{
+			Test: keptnv2.TestFinishedDetails{
+				Start: data.start.Format(time.RFC3339),
+				End:   data.end.Format(time.RFC3339),
+			},
+			EventData: *eventData,
+		}
+		_, err = myKeptn.SendTaskFinishedEvent(event, serviceName)
+	} else {
+		_, err = myKeptn.SendTaskFinishedEvent(eventData, serviceName)
+	}
 
 	if err != nil {
 		log.Printf("Error while sending finished event: %s\n", err.Error())
 		return
 	}
+}
+
+func isTestEvent(eventName string) bool {
+	return strings.HasPrefix(eventName, "sh.keptn.event.test.")
 }

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2" // make sure to use v2 cloudevents here
@@ -130,7 +129,7 @@ func (eh *EventHandler) startK8sJob(k8s k8sutils.K8s, action *config.Action, jso
 		return
 	}
 
-	allJobLogs := []jobLogs{}
+	var allJobLogs []jobLogs
 	additionalFinishedEventData := dataForFinishedEvent{
 		start: time.Now(),
 	}
@@ -234,7 +233,7 @@ func sendTaskFinishedEvent(myKeptn *keptnv2.Keptn, serviceName string, jobLogs [
 
 	var err error
 
-	if isTestEvent(myKeptn.CloudEvent.Type()) && !data.start.IsZero() && !data.end.IsZero() {
+	if isTestTriggeredEvent(myKeptn.CloudEvent.Type()) && !data.start.IsZero() && !data.end.IsZero() {
 		event := &keptnv2.TestFinishedEventData{
 			Test: keptnv2.TestFinishedDetails{
 				Start: data.start.Format(time.RFC3339),
@@ -253,6 +252,6 @@ func sendTaskFinishedEvent(myKeptn *keptnv2.Keptn, serviceName string, jobLogs [
 	}
 }
 
-func isTestEvent(eventName string) bool {
-	return strings.HasPrefix(eventName, "sh.keptn.event.test.")
+func isTestTriggeredEvent(eventName string) bool {
+	return eventName == keptnv2.GetTriggeredEventType(keptnv2.TestTaskName)
 }

--- a/test-events/action.triggered.json
+++ b/test-events/action.triggered.json
@@ -1,29 +1,29 @@
 {
-    "type": "sh.keptn.event.action.triggered",
-    "specversion": "1.0",
-    "source": "test-events",
-    "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79b",
-    "time": "2019-06-07T07:02:15.64489Z",
-    "contenttype": "application/json",
-    "shkeptncontext": "08735340-6f9e-4b32-97ff-3b6c292bc50i",
-    "data": {
-      "project": "sockshop",
-      "stage": "dev",
-      "service": "carts",
-      "labels": {
-        "testId": "4711",
-        "buildId": "build-17",
-        "owner": "JohnDoe"
-      },
-      "status": "succeeded",
-      "result": "pass",
-      "action": {
-        "name": "run locust tests",
-        "action": "hello",
-        "description": "so something as defined in remediation.yaml",
-        "value" : "1"
-      },
-      "problem": {
-      }
+  "type": "sh.keptn.event.action.triggered",
+  "specversion": "1.0",
+  "source": "test-events",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79b",
+  "time": "2019-06-07T07:02:15.64489Z",
+  "contenttype": "application/json",
+  "shkeptncontext": "08735340-6f9e-4b32-97ff-3b6c292bc50i",
+  "data": {
+    "project": "sockshop",
+    "stage": "dev",
+    "service": "carts",
+    "labels": {
+      "testId": "4711",
+      "buildId": "build-17",
+      "owner": "JohnDoe"
+    },
+    "status": "succeeded",
+    "result": "pass",
+    "action": {
+      "name": "run locust tests",
+      "action": "hello",
+      "description": "so something as defined in remediation.yaml",
+      "value": "1"
+    },
+    "problem": {
     }
   }
+}

--- a/test-events/test.triggered.json
+++ b/test-events/test.triggered.json
@@ -1,0 +1,20 @@
+{
+  "type": "sh.keptn.event.test.triggered",
+  "specversion": "1.0",
+  "source": "test-events",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79b",
+  "time": "2021-08-24T08:01:55.484Z",
+  "contenttype": "application/json",
+  "shkeptncontext": "08735340-6f9e-4b32-97ff-3b6c292bc50i",
+  "shkeptnspecversion": "0.2.3",
+  "data": {
+    "project": "sockshop",
+    "stage": "dev",
+    "service": "carts",
+    "result": "pass",
+    "status": "succeeded",
+    "test": {
+      "teststrategy": "health"
+    }
+  }
+}


### PR DESCRIPTION
This commit extends the job ececutor service to send back the start and
end event metadata on test.finished events.

Still TODO:
* Add tests
* Start a discussion if this behaviour should be added for more shipyard tasks beside `test` tasks.