### PR TITLE
docs: add short explanation on howto add the job/config.yaml to the keptn repository for a specific service

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ actions:
             valueFrom: event
 ```
 
+The easiest way to add the `config.yaml` to the keptn git repository is to use the keptn cli:
+
+```shell
+keptn add-resource --project=myproject --service=myservice --stage=mystage --resource=config.yaml --resourceUri=job/config.yaml
+```
+
 ### Specifying the working directory
 
 Since all files are hosted by default under `/keptn` and some tools only operate on the current working directory, it is


### PR DESCRIPTION
In the keptn slack there was a question regarding how to add the `job/config.yaml` for the job-executor service. Best to clarify this for people who don't know the inner workings of keptn that well.

Signed-off-by: Dominik Augustin <dom.augustin@gmx.at>